### PR TITLE
fix: prevent grid items to exceed its container

### DIFF
--- a/src/components/TableUser/data-table.tsx
+++ b/src/components/TableUser/data-table.tsx
@@ -70,7 +70,7 @@ export function DataTable<TData, TValue>({
   });
 
   return (
-    <div className="grid gap-2">
+    <div className="grid gap-2 grid-cols-1">
       <div className="rounded-md border">
         <div className="p-4">
           <DataTableToolbar table={table} withTableViewOptions={true} />


### PR DESCRIPTION
Closes #48.

https://github.com/user-attachments/assets/3204b2ff-b70e-4792-8597-7025e4d01787

