### PR TITLE
feat: add caching mechanism using localStorage

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,7 @@
 import { Route, Routes } from 'react-router-dom';
+import { SWRConfig } from 'swr';
 import { Layout } from './components/Layout';
+import { localCache } from './lib/cache';
 import { About } from './views/About';
 import { Detail } from './views/Detail';
 import ErrorPage from './views/Error';
@@ -7,13 +9,17 @@ import { Home } from './views/Home';
 
 export default function App() {
   return (
-    <Routes>
-      <Route path="/" element={<Layout />}>
-        <Route index element={<Home />} />
-        <Route path="/u/:username" element={<Detail />} />
-        <Route path="about" element={<About />} />
-        <Route path="*" element={<ErrorPage />} />
-      </Route>
-    </Routes>
+    <SWRConfig value={{
+      provider: localCache,
+    }}>
+      <Routes>
+        <Route path="/" element={<Layout />}>
+          <Route index element={<Home />} />
+          <Route path="/u/:username" element={<Detail />} />
+          <Route path="about" element={<About />} />
+          <Route path="*" element={<ErrorPage />} />
+        </Route>
+      </Routes>
+    </SWRConfig>
   );
 }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,4 +1,4 @@
-import useSWR from 'swr';
+import useSWR from 'swr/immutable';
 
 // @ts-ignore
 export const fetcher = (...args) => fetch(...args).then((res) => res.json());

--- a/src/lib/cache.ts
+++ b/src/lib/cache.ts
@@ -1,0 +1,34 @@
+import type { Cache, State } from "swr";
+
+
+const CACHE_LIFETIME = 1_000 * 60 * 60 * 24;
+
+export const localCache = (): Cache => {
+    const map = new Map<string, { data: State<unknown>, timestamp: number }>(JSON.parse(localStorage.getItem('swr-cache') || '[]'));
+
+    window.addEventListener('beforeunload', () => {
+        const cache = Array.from(map.entries());
+
+        localStorage.setItem('swr-cache', JSON.stringify(cache));
+    })
+
+    return {
+        keys: () => map.keys(),
+        get: (key: string) => {
+            const value = map.get(key);
+            if (!value) {
+                return undefined;
+            }
+
+            const { data, timestamp } = value;
+            if (Date.now() - timestamp > CACHE_LIFETIME) {
+                map.delete(key);
+                return undefined;
+            }
+
+            return data;
+        },
+        set: (key: string, value: State<unknown>) => map.set(key, { data: value, timestamp: Date.now() }),
+        delete: (key: string) => map.delete(key),
+    };
+}


### PR DESCRIPTION
## What is the current behavior?

> Please describe the current behavior that you are modifying, or link to a relevant issue.

This PR will resolve #28 

This pull request adds caching mechanism for data that expires in one day span using `localStorage`. Previously, the data will still be fetched on every revalidation which is unnecessary since the data itself is refreshed once per day.

## What is the new behavior?

SWR will now check for cache existence in `localStorage` using [custom provider](https://swr.vercel.app/docs/advanced/cache#localstorage-based-persistent-cache).

If the data exist, SWR will also check whether the data is expired or not. If it's expired, it will return `undefined` and forces SWR to re-fetch the data. If it's not expired, the data is served without having to do any network requests.

## Screenshots

> Sorry for breaking the PR template.

### Before

This network call will always exist on every revalidation scenario.

![Screenshot 2024-11-25 201619](https://github.com/user-attachments/assets/45902507-cf9e-4584-b50c-0e77ddffd084)

### After

First request (same as before)

![Screenshot 2024-11-25 201619](https://github.com/user-attachments/assets/dbb8ece0-02e5-403f-b8a9-241579a6d3c1)

Subsequent request (network call is gone)

![Screenshot 2024-11-25 201640](https://github.com/user-attachments/assets/10c20da6-93d3-4a69-b19d-6df72ccdf0c9) |

## Notes

1. We need to use `swr/immutable` since we are disabling [automatic revalidation](https://swr.vercel.app/docs/revalidation#disable-automatic-revalidations).
2. Since the timestamp is generated locally, the user might receive stale data for a period of time.
