### PR TITLE
FEAT: Limit per_page into 1

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -7,7 +7,7 @@ const ENDPOINT = {
   MOST_ACTIVE_USERS:
     'https://raw.githubusercontent.com/depapp/most-active-github-users-counter/master/indogithubers.json',
   LAST_UPDATED_DATE:
-    'https://api.github.com/repos/depapp/most-active-github-users-counter/commits?path=indogithubers.json',
+    'https://api.github.com/repos/depapp/most-active-github-users-counter/commits?path=indogithubers.json&per_page=1',
 };
 
 export interface User {


### PR DESCRIPTION
## What is the current behavior?

This PR will resolve #65

Adding `per_page` to `1` to limit the number of items requested.

<img width="787" alt="Screenshot 2024-11-26 at 16 27 19" src="https://github.com/user-attachments/assets/34ee0127-1a63-4538-bc41-d37684eb22fc">
