### PR TITLE
CI: New CI to test againts pull request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize]
+  # push:
+  #   branches:
+  #     - main
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm i
+
+      - name: Run npm audit
+        run: npm audit
+
+      - name: Run biome check
+        run: npm run check
+
+      - name: Run build
+        run: npm run build

--- a/.kodiak.toml
+++ b/.kodiak.toml
@@ -1,0 +1,34 @@
+version = 1
+
+[merge]
+# Label to enable Kodiak to merge a PR.
+
+# By default, Kodiak will only act on PRs that have this label. You can disable
+# this requirement via `merge.require_automerge_label`.
+automerge_label = "automerge" # default: "automerge"
+
+# Require that the automerge label (`merge.automerge_label`) be set for Kodiak
+# to merge a PR.
+#
+# When disabled, Kodiak will immediately attempt to merge any PR that passes all
+# GitHub branch protection requirements.
+require_automerge_label = true
+
+[update]
+always = true # default: false
+ignored_usernames = ["dependabot", "snyk-bot"]
+
+[approve]
+auto_approve_usernames = ["ImgBotApp", "imgbot"]
+
+[merge.automerge_dependencies]
+versions = ["minor", "patch"]
+usernames = ["dependabot", "snyk-bot"]
+
+# https://kodiakhq.com/docs/recipes#better-merge-messages
+[merge.message]
+
+title = "pull_request_title" # default: "github_default"
+body = "pull_request_body" # default: "github_default"
+include_pr_number = true
+include_coauthors = true

--- a/dependabot.yml
+++ b/dependabot.yml
@@ -1,0 +1,11 @@
+# Basic set up for three package managers
+version: 2
+updates:
+  # Maintain dependencies for npm
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      # Prefix all commit messages with "npm: "
+      prefix: "npm"

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@vercel/analytics": "^1.4.1",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
-        "lucide-react": "^0.465.0",
+        "lucide-react": "^0.468.0",
         "nuqs": "^2.2.3",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -39,8 +39,8 @@
         "@biomejs/biome": "1.9.4",
         "@playwright/test": "1.49.0",
         "@types/node": "^22.10.1",
-        "@types/react": "^18.3.13",
-        "@types/react-dom": "^18.3.1",
+        "@types/react": "^18.3.14",
+        "@types/react-dom": "^18.3.3",
         "@vitejs/plugin-react": "^4.3.4",
         "autoprefixer": "10.4.20",
         "husky": "^9.1.7",
@@ -48,7 +48,7 @@
         "postcss": "8.4.49",
         "tailwindcss": "3.4.16",
         "typescript": "5.7.2",
-        "vite": "^6.0.2"
+        "vite": "^6.0.3"
       },
       "engines": {
         "node": "^20.x",
@@ -3634,13 +3634,13 @@
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "18.3.2",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.2.tgz",
-      "integrity": "sha512-Fqp+rcvem9wEnGr3RY8dYNvSQ8PoLqjZ9HLgaPUOjJJD120uDyOxOjc/39M4Kddp9JQCxpGQbnhVQF0C0ncYVg==",
+      "version": "18.3.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.3.tgz",
+      "integrity": "sha512-uTYkxTLkYp41nq/ULXyXMtkNT1vu5fXJoqad6uTNCOGat5t9cLgF4vMNLBXsTOXpdOI44XzKPY1M5RRm0bQHuw==",
       "devOptional": true,
       "license": "MIT",
-      "dependencies": {
-        "@types/react": "^18"
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
       }
     },
     "node_modules/@types/resolve": {
@@ -6021,9 +6021,9 @@
       }
     },
     "node_modules/lucide-react": {
-      "version": "0.465.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.465.0.tgz",
-      "integrity": "sha512-uV7WEqbwaCcc+QjAxIhAvkAr3kgwkkYID3XptCHll72/F7NZlk6ONmJYpk+Xqx5Q0r/8wiOjz73H1BYbl8Z8iw==",
+      "version": "0.468.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.468.0.tgz",
+      "integrity": "sha512-6koYRhnM2N0GGZIdXzSeiNwguv1gt/FAjZOiPl76roBi3xKEXa4WmfpxgQwTTL4KipXjefrnf3oV4IsYhi4JFA==",
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc"

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "postinstall": "husky",
     "lint": "biome lint --write",
     "lint:unsafe": "biome lint --write --unsafe",
+    "lint:ci": "biome lint",
     "preview": "vite preview",
     "test:setup": "npx playwright install --with-deps",
     "test:e2e": "playwright test",
@@ -37,7 +38,7 @@
     "@vercel/analytics": "^1.4.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "lucide-react": "^0.465.0",
+    "lucide-react": "^0.468.0",
     "nuqs": "^2.2.3",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
@@ -53,8 +54,8 @@
     "@biomejs/biome": "1.9.4",
     "@playwright/test": "1.49.0",
     "@types/node": "^22.10.1",
-    "@types/react": "^18.3.13",
-    "@types/react-dom": "^18.3.1",
+    "@types/react": "^18.3.14",
+    "@types/react-dom": "^18.3.3",
     "@vitejs/plugin-react": "^4.3.4",
     "autoprefixer": "10.4.20",
     "husky": "^9.1.7",
@@ -62,7 +63,7 @@
     "postcss": "8.4.49",
     "tailwindcss": "3.4.16",
     "typescript": "5.7.2",
-    "vite": "^6.0.2"
+    "vite": "^6.0.3"
   },
   "packageManager": "npm@^10.8.2",
   "engines": {

--- a/src/components/mode-toggle.tsx
+++ b/src/components/mode-toggle.tsx
@@ -1,5 +1,6 @@
 import { Moon, Sun } from 'lucide-react'
 
+import { useTheme } from '@/components/theme-provider'
 import { Button } from '@/components/ui/button'
 import {
   DropdownMenu,
@@ -7,7 +8,6 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
-import { useTheme } from '@/components/theme-provider'
 
 export function ModeToggle() {
   const { setTheme } = useTheme()

--- a/src/components/ui/accordion.tsx
+++ b/src/components/ui/accordion.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react'
 import * as AccordionPrimitive from '@radix-ui/react-accordion'
 import { ChevronDown } from 'lucide-react'
+import * as React from 'react'
 
 import { cn } from '@/lib/utils'
 

--- a/src/components/ui/alert.tsx
+++ b/src/components/ui/alert.tsx
@@ -1,5 +1,5 @@
+import { type VariantProps, cva } from 'class-variance-authority'
 import * as React from 'react'
-import { cva, type VariantProps } from 'class-variance-authority'
 
 import { cn } from '@/lib/utils'
 

--- a/src/components/ui/avatar.tsx
+++ b/src/components/ui/avatar.tsx
@@ -1,5 +1,5 @@
-import * as React from 'react'
 import * as AvatarPrimitive from '@radix-ui/react-avatar'
+import * as React from 'react'
 
 import { cn } from '@/lib/utils'
 

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react'
 import { Slot } from '@radix-ui/react-slot'
-import { cva, type VariantProps } from 'class-variance-authority'
+import { type VariantProps, cva } from 'class-variance-authority'
+import * as React from 'react'
 
 import { cn } from '@/lib/utils'
 

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react'
 import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu'
 import { Check, ChevronRight, Circle } from 'lucide-react'
+import * as React from 'react'
 
 import { cn } from '@/lib/utils'
 

--- a/src/components/ui/pagination.tsx
+++ b/src/components/ui/pagination.tsx
@@ -1,8 +1,8 @@
-import * as React from 'react'
 import { ChevronLeft, ChevronRight, MoreHorizontal } from 'lucide-react'
+import * as React from 'react'
 
-import { cn } from '@/lib/utils'
 import { type ButtonProps, buttonVariants } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
 
 const Pagination = ({ className, ...props }: React.ComponentProps<'nav'>) => (
   <nav

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -1,5 +1,5 @@
-import * as React from 'react'
 import * as PopoverPrimitive from '@radix-ui/react-popover'
+import * as React from 'react'
 
 import { cn } from '@/lib/utils'
 

--- a/src/components/ui/progress.tsx
+++ b/src/components/ui/progress.tsx
@@ -1,5 +1,5 @@
-import * as React from 'react'
 import * as ProgressPrimitive from '@radix-ui/react-progress'
+import * as React from 'react'
 
 import { cn } from '@/lib/utils'
 

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react'
 import * as SelectPrimitive from '@radix-ui/react-select'
 import { Check, ChevronDown, ChevronUp } from 'lucide-react'
+import * as React from 'react'
 
 import { cn } from '@/lib/utils'
 

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -1,5 +1,5 @@
-import * as React from 'react'
 import * as TabsPrimitive from '@radix-ui/react-tabs'
+import * as React from 'react'
 
 import { cn } from '@/lib/utils'
 

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -1,5 +1,5 @@
-import * as React from 'react'
 import * as TooltipPrimitive from '@radix-ui/react-tooltip'
+import * as React from 'react'
 
 import { cn } from '@/lib/utils'
 


### PR DESCRIPTION
## What is the current behavior?

This PR will close #99

Adding new CI to run in all pull request

Running:

- npm audit -- to test vulnerability dependencies
- npm run check -- validate biome rules (lint and format)
- npm run build -- build project for deployment
